### PR TITLE
support ssh with private ip address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 1.3.0 (Unreleased)
 
+## 1.2.1 (September 11, 2018)
+
+IMPROVEMENTS:
+
+- Support ssh with private ip address ([#42](https://github.com/alibaba/packer-provider/pull/42))
+
 ## 1.2.0 (August 14, 2018)
 
 IMPROVEMENTS:

--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -141,10 +141,12 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			RegionId:                 b.config.AlicloudRegion,
 			InternetChargeType:       b.config.InternetChargeType,
 			InternetMaxBandwidthOut:  b.config.InternetMaxBandwidthOut,
+			SSHPrivateIp:             b.config.SSHPrivateIp,
 		})
 	} else {
 		steps = append(steps, &stepConfigAlicloudPublicIP{
-			RegionId: b.config.AlicloudRegion,
+			RegionId:     b.config.AlicloudRegion,
+			SSHPrivateIp: b.config.SSHPrivateIp,
 		})
 	}
 	steps = append(steps,

--- a/ecs/run_config_test.go
+++ b/ecs/run_config_test.go
@@ -123,3 +123,33 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 		t.Fatal("keypair name does not match")
 	}
 }
+
+func TestRunConfigPrepare_SSHPrivateIp(t *testing.T) {
+	c := testConfig()
+
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c.SSHPrivateIp != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.SSHPrivateIp)
+	}
+
+	c.SSHPrivateIp = true
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c.SSHPrivateIp != true {
+		t.Fatalf("invalid value, expected: %t, actul: %t", true, c.SSHPrivateIp)
+	}
+
+	c.SSHPrivateIp = false
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c.SSHPrivateIp != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.SSHPrivateIp)
+	}
+}

--- a/ecs/step_config_eip.go
+++ b/ecs/step_config_eip.go
@@ -16,12 +16,25 @@ type stepConfigAlicloudEIP struct {
 	InternetChargeType       string
 	InternetMaxBandwidthOut  int
 	allocatedId              string
+	SSHPrivateIp             bool
 }
 
 func (s *stepConfigAlicloudEIP) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
+
+	if s.SSHPrivateIp {
+		ipaddress := instance.VpcAttributes.PrivateIpAddress.IpAddress
+		if len(ipaddress) == 0 {
+			ui.Say("Failed to get private ip of instance")
+			return multistep.ActionHalt
+		}
+
+		state.Put("ipaddress", ipaddress[0])
+		return multistep.ActionContinue
+	}
+
 	ui.Say("Allocating eip")
 	ipaddress, allocateId, err := client.AllocateEipAddress(&ecs.AllocateEipAddressArgs{
 		RegionId: common.Region(s.RegionId), InternetChargeType: common.InternetChargeType(s.InternetChargeType),

--- a/ecs/step_config_public_ip.go
+++ b/ecs/step_config_public_ip.go
@@ -12,12 +12,24 @@ import (
 type stepConfigAlicloudPublicIP struct {
 	publicIPAddress string
 	RegionId        string
+	SSHPrivateIp    bool
 }
 
 func (s *stepConfigAlicloudPublicIP) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
+
+	if s.SSHPrivateIp {
+		ipaddress := instance.InnerIpAddress.IpAddress
+		if len(ipaddress) == 0 {
+			ui.Say("Failed to get private ip of instance")
+			return multistep.ActionHalt
+		}
+
+		state.Put("ipaddress", ipaddress[0])
+		return multistep.ActionContinue
+	}
 
 	ipaddress, err := client.AllocatePublicIpAddress(instance.InstanceId)
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,6 +123,12 @@
 			"revisionTime": "2017-07-14T14:01:51Z"
 		},
 		{
+			"checksumSHA1": "R/C/tPGxwBRK+AXiyFKQCuZ97to=",
+			"path": "github.com/hashicorp/packer/helper/builder/testing",
+			"revision": "351cdc85086c8d82de3d0b6eef4014f6b40db5e5",
+			"revisionTime": "2018-09-10T19:12:40Z"
+		},
+		{
 			"checksumSHA1": "q2aQ4NsFrC4oSfFnEy2dGsFoURg=",
 			"path": "github.com/hashicorp/packer/helper/common",
 			"revision": "39fc8593deae0999d211c482cd756cd4fdc55832",


### PR DESCRIPTION
If `ssh_private_ip="true"` is provided in alicloud.json, packer will connect to the ECS created through private ip instead of allocating a public ip or an EIP.