### PR TITLE
support disable_stop_instance option for some specific scenarios

### DIFF
--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -165,7 +165,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		},
 		&common.StepProvision{},
 		&stepStopAlicloudInstance{
-			ForceStop: b.config.ForceStopInstance,
+			ForceStop:   b.config.ForceStopInstance,
+			DisableStop: b.config.DisableStopInstance,
 		},
 		&stepDeleteAlicloudImageSnapshots{
 			AlicloudImageForceDeleteSnapshots: b.config.AlicloudImageForceDeleteSnapshots,

--- a/ecs/run_config.go
+++ b/ecs/run_config.go
@@ -19,6 +19,7 @@ type RunConfig struct {
 	Description              string `mapstructure:"description"`
 	AlicloudSourceImage      string `mapstructure:"source_image"`
 	ForceStopInstance        bool   `mapstructure:"force_stop_instance"`
+	DisableStopInstance      bool   `mapstructure:"disable_stop_instance"`
 	SecurityGroupId          string `mapstructure:"security_group_id"`
 	SecurityGroupName        string `mapstructure:"security_group_name"`
 	UserData                 string `mapstructure:"user_data"`

--- a/ecs/run_config_test.go
+++ b/ecs/run_config_test.go
@@ -153,3 +153,27 @@ func TestRunConfigPrepare_SSHPrivateIp(t *testing.T) {
 		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.SSHPrivateIp)
 	}
 }
+
+func TestRunConfigPrepare_DisableStopInstance(t *testing.T) {
+	c := testConfig()
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.DisableStopInstance != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.DisableStopInstance)
+	}
+	c.DisableStopInstance = true
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.DisableStopInstance != true {
+		t.Fatalf("invalid value, expected: %t, actul: %t", true, c.DisableStopInstance)
+	}
+	c.DisableStopInstance = false
+	if err := c.Prepare(nil); len(err) != 0 {
+		t.Fatalf("err: %s", err)
+	}
+	if c.DisableStopInstance != false {
+		t.Fatalf("invalid value, expected: %t, actul: %t", false, c.DisableStopInstance)
+	}
+}

--- a/ecs/step_delete_images_snapshots.go
+++ b/ecs/step_delete_images_snapshots.go
@@ -21,7 +21,7 @@ func (s *stepDeleteAlicloudImageSnapshots) Run(_ context.Context, state multiste
 	client := state.Get("client").(*ecs.Client)
 	ui := state.Get("ui").(packer.Ui)
 	config := state.Get("config").(Config)
-	ui.Say("Deleting image snapshots.")
+
 	// Check for force delete
 	if s.AlicloudImageForceDelete {
 		images, _, err := client.DescribeImages(&ecs.DescribeImagesArgs{
@@ -31,6 +31,9 @@ func (s *stepDeleteAlicloudImageSnapshots) Run(_ context.Context, state multiste
 		if len(images) < 1 {
 			return multistep.ActionContinue
 		}
+
+		ui.Say(fmt.Sprintf("Deleting duplicated image and snapshot: %s", s.AlicloudImageName))
+
 		for _, image := range images {
 			if image.ImageOwnerAlias != string(ecs.ImageOwnerSelf) {
 				log.Printf("You can only delete instances based on customized images %s ", image.ImageId)

--- a/ecs/step_run_instance.go
+++ b/ecs/step_run_instance.go
@@ -24,7 +24,9 @@ func (s *stepRunAlicloudInstance) Run(_ context.Context, state multistep.StateBa
 		ui.Error(err.Error())
 		return multistep.ActionHalt
 	}
-	ui.Say("Starting instance.")
+
+	ui.Say(fmt.Sprintf("Starting instance: %s", instance.InstanceId))
+
 	err = client.WaitForInstance(instance.InstanceId, ecs.Running, ALICLOUD_DEFAULT_TIMEOUT)
 	if err != nil {
 		err := fmt.Errorf("Timeout waiting for instance to start: %s", err)

--- a/ecs/step_stop_instance.go
+++ b/ecs/step_stop_instance.go
@@ -10,7 +10,8 @@ import (
 )
 
 type stepStopAlicloudInstance struct {
-	ForceStop bool
+	ForceStop   bool
+	DisableStop bool
 }
 
 func (s *stepStopAlicloudInstance) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
@@ -18,8 +19,10 @@ func (s *stepStopAlicloudInstance) Run(_ context.Context, state multistep.StateB
 	instance := state.Get("instance").(*ecs.InstanceAttributesType)
 	ui := state.Get("ui").(packer.Ui)
 
-	err := client.StopInstance(instance.InstanceId, s.ForceStop)
-	if err != nil {
+	if !s.DisableStop {
+		ui.Say(fmt.Sprintf("Stopping instance: %s", instance.InstanceId))
+		err := client.StopInstance(instance.InstanceId, s.ForceStop)
+
 		if err != nil {
 			err := fmt.Errorf("Error stopping alicloud instance: %s", err)
 			state.Put("error", err)
@@ -28,7 +31,9 @@ func (s *stepStopAlicloudInstance) Run(_ context.Context, state multistep.StateB
 		}
 	}
 
-	err = client.WaitForInstance(instance.InstanceId, ecs.Stopped, ALICLOUD_DEFAULT_TIMEOUT)
+	ui.Say(fmt.Sprintf("Waiting instance stopped: %s", instance.InstanceId))
+
+	err := client.WaitForInstance(instance.InstanceId, ecs.Stopped, ALICLOUD_DEFAULT_TIMEOUT)
 	if err != nil {
 		err := fmt.Errorf("Error waiting for alicloud instance to stop: %s", err)
 		state.Put("error", err)


### PR DESCRIPTION
support disable_stop_instance option. If this option is set to true, Packer will not stop the instance. It is used to support scenarios that user want to stop the instance by themselves, like Sysprep a windows which may shutdown the instance in its command.