### PR TITLE
delete copied image and snapshots if corresponding options are specified

### DIFF
--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -57,6 +57,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
+	if b.config.PackerConfig.PackerForce {
+		b.config.AlicloudImageForceDelete = true
+		b.config.AlicloudImageForceDeleteSnapshots = true
+	}
+
 	// Accumulate any errors
 	var errs *packer.MultiError
 	errs = packer.MultiErrorAppend(errs, b.config.AlicloudAccessConfig.Prepare(&b.config.ctx)...)

--- a/ecs/builder.go
+++ b/ecs/builder.go
@@ -172,6 +172,8 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			AlicloudImageForceDeleteSnapshots: b.config.AlicloudImageForceDeleteSnapshots,
 			AlicloudImageForceDelete:          b.config.AlicloudImageForceDelete,
 			AlicloudImageName:                 b.config.AlicloudImageName,
+			AlicloudImageDestinationRegions:   b.config.AlicloudImageConfig.AlicloudImageDestinationRegions,
+			AlicloudImageDestinationNames:     b.config.AlicloudImageConfig.AlicloudImageDestinationNames,
 		})
 
 	if b.config.AlicloudImageIgnoreDataDisks {

--- a/ecs/packer_helper.go
+++ b/ecs/packer_helper.go
@@ -24,7 +24,10 @@ func message(state multistep.StateBag, module string) {
 func halt(state multistep.StateBag, err error, prefix string) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 
-	err = fmt.Errorf("%s: %s", prefix, err)
+	if prefix != "" {
+		err = fmt.Errorf("%s: %s", prefix, err)
+	}
+
 	state.Put("error", err)
 	ui.Error(err.Error())
 	return multistep.ActionHalt

--- a/ecs/step_delete_images_snapshots.go
+++ b/ecs/step_delete_images_snapshots.go
@@ -15,52 +15,81 @@ type stepDeleteAlicloudImageSnapshots struct {
 	AlicloudImageForceDelete          bool
 	AlicloudImageForceDeleteSnapshots bool
 	AlicloudImageName                 string
+	AlicloudImageDestinationRegions   []string
+	AlicloudImageDestinationNames     []string
 }
 
 func (s *stepDeleteAlicloudImageSnapshots) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
-	client := state.Get("client").(*ecs.Client)
-	ui := state.Get("ui").(packer.Ui)
 	config := state.Get("config").(Config)
 
 	// Check for force delete
 	if s.AlicloudImageForceDelete {
-		images, _, err := client.DescribeImages(&ecs.DescribeImagesArgs{
-			RegionId:  common.Region(config.AlicloudRegion),
-			ImageName: s.AlicloudImageName,
-		})
-		if len(images) < 1 {
+		err := s.deleteImageAndSnapshots(state, s.AlicloudImageName, config.AlicloudRegion)
+		if err != nil {
+			return halt(state, err, "")
+		}
+
+		numberOfName := len(s.AlicloudImageDestinationNames)
+		if numberOfName == 0 {
 			return multistep.ActionContinue
 		}
 
-		ui.Say(fmt.Sprintf("Deleting duplicated image and snapshot: %s", s.AlicloudImageName))
-
-		for _, image := range images {
-			if image.ImageOwnerAlias != string(ecs.ImageOwnerSelf) {
-				log.Printf("You can only delete instances based on customized images %s ", image.ImageId)
+		for index, destinationRegion := range s.AlicloudImageDestinationRegions {
+			if destinationRegion == config.AlicloudRegion {
 				continue
 			}
-			err = client.DeleteImage(common.Region(config.AlicloudRegion), image.ImageId)
-			if err != nil {
-				err := fmt.Errorf("Failed to delete image: %s", err)
-				state.Put("error", err)
-				ui.Error(err.Error())
-				return multistep.ActionHalt
-			}
-			if s.AlicloudImageForceDeleteSnapshots {
-				for _, diskDevice := range image.DiskDeviceMappings.DiskDeviceMapping {
-					if err := client.DeleteSnapshot(diskDevice.SnapshotId); err != nil {
-						err := fmt.Errorf("Deleting ECS snapshot failed: %s", err)
-						state.Put("error", err)
-						ui.Error(err.Error())
-						return multistep.ActionHalt
-					}
+
+			if index < numberOfName {
+				err = s.deleteImageAndSnapshots(state, s.AlicloudImageDestinationNames[index], destinationRegion)
+				if err != nil {
+					return halt(state, err, "")
 				}
+			} else {
+				break
 			}
 		}
-
 	}
 
 	return multistep.ActionContinue
+}
+
+func (s *stepDeleteAlicloudImageSnapshots) deleteImageAndSnapshots(state multistep.StateBag, imageName string, region string) error {
+	client := state.Get("client").(*ecs.Client)
+	ui := state.Get("ui").(packer.Ui)
+
+	images, _, err := client.DescribeImages(&ecs.DescribeImagesArgs{
+		RegionId:  common.Region(region),
+		ImageName: imageName,
+	})
+	if len(images) < 1 {
+		return nil
+	}
+
+	ui.Say(fmt.Sprintf("Deleting duplicated image and snapshot in %s: %s", region, imageName))
+
+	for _, image := range images {
+		if image.ImageOwnerAlias != string(ecs.ImageOwnerSelf) {
+			log.Printf("You can not delete non-customized images: %s ", image.ImageId)
+			continue
+		}
+
+		err = client.DeleteImage(common.Region(region), image.ImageId)
+		if err != nil {
+			err := fmt.Errorf("Failed to delete image: %s", err)
+			return err
+		}
+
+		if s.AlicloudImageForceDeleteSnapshots {
+			for _, diskDevice := range image.DiskDeviceMappings.DiskDeviceMapping {
+				if err := client.DeleteSnapshot(diskDevice.SnapshotId); err != nil {
+					err := fmt.Errorf("Deleting ECS snapshot failed: %s", err)
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *stepDeleteAlicloudImageSnapshots) Cleanup(state multistep.StateBag) {


### PR DESCRIPTION
If `image_force_delete` and `image_force_delete_snapshots` are set to `true`, not only duplicated image in source region will be deleted, but also those in `image_copy_regions` will be deleted according to `image_copy_names`.