### PR TITLE
cleanup image and snapshot if target image is still not available after timeout

### DIFF
--- a/ecs/client.go
+++ b/ecs/client.go
@@ -161,6 +161,7 @@ func (c *ClientWrapper) WaitForExpected(args *WaitForExpectArgs) (responses.AcsR
 		timeoutPoint = time.Now().Add(args.RetryTimeout)
 	}
 
+	var lastResponse responses.AcsResponse
 	var lastError error
 
 	for i := 0; ; i++ {
@@ -173,6 +174,7 @@ func (c *ClientWrapper) WaitForExpected(args *WaitForExpectArgs) (responses.AcsR
 		}
 
 		response, err := args.RequestFunc()
+		lastResponse = response
 		lastError = err
 
 		evalResult := args.EvalFunc(response, err)
@@ -180,17 +182,21 @@ func (c *ClientWrapper) WaitForExpected(args *WaitForExpectArgs) (responses.AcsR
 			return response, nil
 		}
 		if evalResult.stopRetry {
-			return nil, err
+			return response, err
 		}
 
 		time.Sleep(args.RetryInterval)
 	}
 
-	if args.RetryTimeout > 0 {
-		return nil, fmt.Errorf("evaluate failed after %d seconds timeout with %d seconds retry interval: %s", int(args.RetryTimeout.Seconds()), int(args.RetryInterval.Seconds()), lastError)
+	if lastError == nil {
+		lastError = fmt.Errorf("<no error>")
 	}
 
-	return nil, fmt.Errorf("evaluate failed after %d times retry with %d seconds retry interval: %s", args.RetryTimes, int(args.RetryInterval.Seconds()), lastError)
+	if args.RetryTimeout > 0 {
+		return lastResponse, fmt.Errorf("evaluate failed after %d seconds timeout with %d seconds retry interval: %s", int(args.RetryTimeout.Seconds()), int(args.RetryInterval.Seconds()), lastError)
+	}
+
+	return lastResponse, fmt.Errorf("evaluate failed after %d times retry with %d seconds retry interval: %s", args.RetryTimes, int(args.RetryInterval.Seconds()), lastError)
 }
 
 func (c *ClientWrapper) WaitForInstanceStatus(regionId string, instanceId string, expectedStatus string) (responses.AcsResponse, error) {

--- a/ecs/step_create_snapshot.go
+++ b/ecs/step_create_snapshot.go
@@ -3,8 +3,9 @@ package ecs
 import (
 	"context"
 	"fmt"
-	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"time"
+
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/hashicorp/packer/helper/multistep"


### PR DESCRIPTION
If target image is still not availabe after waiting timeout, the image and snapshot will not be cleaned up for now. This PR is going to clean them if timeout occurred.